### PR TITLE
Fix a dbus method GetCategoryActivities(category_id)

### DIFF
--- a/src/hamster-service
+++ b/src/hamster-service
@@ -260,7 +260,7 @@ class Storage(db.Storage, dbus.service.Object):
         return [(row['id'],
                  row['name'],
                  row['category_id'],
-                 row['name'] or '') for row in
+                 row['category'] or '') for row in
                       self.get_category_activities(category_id = category_id)]
 
 


### PR DESCRIPTION
Problem:
    Method GetCategoryActivities(category_id) returns struct with
    the activity name two times. In author intension method should
    return category name instead of activity name again.

Solution:
    Return category name instead of activity name on the fourth member
    of returned struct.

Verification:
    1. Run d-feet.
    2. Pick unique bus name - org.gnome.Hamster,
            object path - /org/gnome/Hamster,
            interface - org.gnome.Hamster,
            method - GetCategoryActivities
    3. Type '1' in 'method input' view and press 'Execute'.
    4. You should see result in 'method output'.
       In the result, the 4th member (category name) of each row should be the same.
